### PR TITLE
Allow folding of tags with hardcoded attributes

### DIFF
--- a/AutoFold.py
+++ b/AutoFold.py
@@ -88,7 +88,7 @@ class AutoFoldListener(sublime_plugin.EventListener):
   def fold_tags(self, view, tags):
     for tag in tags:
       result = view.find_all(r'(?<=<' + re.escape(tag) + '>)(.|\n)*?(?=</'
-             + re.escape(tag) + '>)', sublime.IGNORECASE)
+             + re.escape(tag.split(" ")[0]) + '>)', sublime.IGNORECASE)
       view.fold(result)
 
 


### PR DESCRIPTION
Summary
---

* folding currently only works with empty tags
* if a tag is specified in settings with hardcoded attribute string, it can be folded

Example
---

```json
  "tags": [
    "abc hardcoded_attr=\"hardcoded_value\""
  ]
```